### PR TITLE
更灵活地在预训练特征提取网络中注入钩子

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,52 @@
 # GLASS project
 results/
 
-# build
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
 *.egg
-*.wheel
-*.build
-*.pyc
-*.pyo
+MANIFEST
 
-# virtual env
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Environments
+.env
+.venv
+env/
 venv/
-
-# log
-*.log
-
-# temporary files
-*.tmp
-*.swp
-*.bak
-*.tmp
-*.swp
-*.bak
+ENV/
+env.bak/
+venv.bak/
 
 # IDE profiles
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# GLASS project
+results/
+
+# build
+*.egg
+*.wheel
+*.build
+*.pyc
+*.pyo
+
+# virtual env
+venv/
+
+# log
+*.log
+
+# temporary files
+*.tmp
+*.swp
+*.bak
+*.tmp
+*.swp
+*.bak
+
+# IDE profiles
+.idea/
+.vscode/
+
+# private keys
+*.pem
+*.key
+*.crt
+
+# virtual machine
+*.vmss
+*.vmem
+*.vdi
+*.iso
+
+# system
+.DS_Store
+Thumbs.db

--- a/main.py
+++ b/main.py
@@ -299,7 +299,7 @@ def run(
                 flag = GLASS.trainer(dataloaders["training"], dataloaders["testing"], dataset_name)
                 if type(flag) == int:
                     row_dist = {'Class': dataloaders["training"].name, 'Distribution': flag, 'Foreground': flag}
-                    df = df.append(row_dist, ignore_index=True)
+                    df = pd.concat([df, pd.DataFrame(row_dist, index=[0])])
 
             if type(flag) != int:
                 i_auroc, i_ap, p_auroc, p_ap, p_pro, epoch = GLASS.tester(dataloaders["testing"], dataset_name)


### PR DESCRIPTION
1.如果要将主干网络换成 swin transformer，由于其网络结构中 layers 内的层只有 0,1,2... 的编号，现有以层名字访问的方式无法获取。修改之后，可以用 "layers.0", "layers.2.blocks.0" 这样以'.'隔开的级联方式，访问任意深度的模块。从而更灵活地注入钩子.
2.增加了一个.gitignore 文件.
3.用 pd.concat 替换了 DataFrame.append 方法，新版pandas已弃用append.